### PR TITLE
Support debug cookie on preview mode

### DIFF
--- a/src/Datalayer.ts
+++ b/src/Datalayer.ts
@@ -22,7 +22,7 @@ export const subscribeToCampaign = (callback, campaignId) => {
 const findCampaignValue = (callback, campaignId) => {
     let attempts = 0;
     let interval = setInterval(function(){                
-        let campaignVal = getCookie(`_vis_opt_exp_${campaignId}_combi`);
+        let campaignVal = getCookie(`debug_vis_opt_exp_${campaignId}_combi`) || getCookie(`_vis_opt_exp_${campaignId}_combi`);
         if(campaignVal){
             clearInterval(interval);
             passCampaign(callback, campaignId, campaignVal);


### PR DESCRIPTION
On preview mode, the cookie value starts with `debug_ `. (e.g. debug_vis_opt_exp_102_combi).

And we should support debug cookie as well.

Check out the following screenshot, please

![Screenshot at Apr 22 00-31-26](https://user-images.githubusercontent.com/18234060/56489367-57a7d680-6496-11e9-9aea-aca6cea0862e.png)
